### PR TITLE
Add note on thread-safety to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ and support encryption of individual messages or message streams.
 import "github.com/miscreant/miscreant-go"
 ```
 
+All types are designed to be **thread-compatible**: Methods of an instance shared between
+multiple threads (or goroutines) must not be accessed concurrently. Callers are responsible for
+implementing their own mutual exclusion.
+
+
 - [Documentation] (Wiki)
 - [godoc][godoc-link]
 


### PR DESCRIPTION
Many Miscreant types (e.g. `miscreant.Cipher`) share intermediate state between methods. It would be nice to add a note to the README, explicitly calling out that these types are *thread-compatible*, and that their use requires external synchronization. While it might be fair to assume that this ought to be the "default" for most types, prominently drawing attention to it can be helpful.