### PR TITLE
fix build issue in aead.go

### DIFF
--- a/aead.go
+++ b/aead.go
@@ -5,6 +5,7 @@ package miscreant
 import (
 	"crypto/cipher"
 	"crypto/rand"
+	"fmt"
 	"io"
 )
 
@@ -24,7 +25,7 @@ type aead struct {
 // Panics if the key size is unsupported or source of randomness fails.
 func GenerateKey(length int) []byte {
 	if length != 32 && length != 64 {
-		panic("miscreant.GenerateKey: invalid key size: " + string(length))
+		panic(fmt.Sprintf("miscreant.GenerateKey: invalid key size: %d", length))
 	}
 
 	key := make([]byte, length)
@@ -40,7 +41,7 @@ func GenerateKey(length int) []byte {
 // Panics if the configured nonce size is less than 16-bytes (128-bits)
 func GenerateNonce(c cipher.AEAD) []byte {
 	if c.NonceSize() < minimumRandomNonceSize {
-		panic("miscreant.GenerateNonce: nonce size is too small: " + string(c.NonceSize()))
+		panic(fmt.Sprintf("miscreant.GenerateNonce: nonce size is too small: %d", c.NonceSize()))
 	}
 
 	nonce := make([]byte, c.NonceSize())


### PR DESCRIPTION
Hi! In go 1.15 the build is failing with

```
./aead.go:27:55: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./aead.go:43:64: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

This PR fixes that.